### PR TITLE
Add REST API server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ lint:
 	npx eslint *.js
 
 
+serve:
+	node server.js
+
 publish:
 	./publish.sh $(files)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 
 
 serve:
-	node server.js
+	cd server && node index.js
 
 publish:
 	./publish.sh $(files)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bells",
+  "name": "bells-server",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "type": "module",
-  "scripts": {
-    "start": "node server.js"
-  },
-  "dependencies": {
+"dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
     "@peterseibel/bells": "^0.1.9",
     "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "@js-temporal/polyfill": "^0.4.4",
+    "@peterseibel/bells": "^0.1.9",
     "cors": "^2.8.5",
     "esbuild": "0.23.0",
     "temporal-polyfill": "^0.2.5"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,149 @@
+/**
+ * Bells REST API server — wraps @peterseibel/bells for HTTP access.
+ *
+ * Endpoints:
+ *   GET /api/current  — current interval (period, passing, break, etc.)
+ *   GET /api/schedule — periods for the current (or next) school day
+ *   GET /api/status   — full status: interval + day bounds + year counters
+ *
+ * Query parameters (all endpoints):
+ *   role=student|teacher    default: student
+ *   includeTags=zero,seventh,ext   optional periods to include (comma-separated)
+ *   time=<ISO 8601 instant> override "now" for testing (e.g. 2026-01-15T10:30:00-08:00)
+ *
+ * Environment:
+ *   PORT            default: 3000
+ *   CALENDARS_PATH  path to calendars/ directory, default: <script dir>/calendars/
+ */
+
+import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { Temporal } from '@js-temporal/polyfill';
+import { Calendars } from '@peterseibel/bells/calendars';
+
+globalThis.Temporal = Temporal;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = process.env.PORT || 3000;
+const CALENDARS_PATH = process.env.CALENDARS_PATH ?? join(__dirname, 'calendars') + '/';
+
+const calendars = new Calendars(CALENDARS_PATH);
+
+function parseOptions(searchParams) {
+  const role = searchParams.get('role') || 'student';
+  const raw = searchParams.get('includeTags');
+  const includeTags = raw ? raw.split(',').map((s) => s.trim()).filter(Boolean) : [];
+  return { role, includeTags };
+}
+
+function parseInstant(searchParams) {
+  const raw = searchParams.get('time');
+  return raw ? Temporal.Instant.from(raw) : Temporal.Now.instant();
+}
+
+function durationToSeconds(duration) {
+  return Math.round(duration.total({ unit: 'seconds' }));
+}
+
+function serializeInterval(interval, now) {
+  if (!interval) return null;
+  return {
+    name: interval.name,
+    type: interval.type,
+    start: interval.start.toString(),
+    end: interval.end.toString(),
+    secondsLeft: durationToSeconds(interval.left(now)),
+    secondsDone: durationToSeconds(interval.done(now)),
+    duringSchool: interval.duringSchool,
+    tags: interval.tags,
+  };
+}
+
+async function handleCurrent(url) {
+  const options = parseOptions(url.searchParams);
+  const instant = parseInstant(url.searchParams);
+  const schedule = await calendars.current(options);
+  return { interval: serializeInterval(schedule.currentInterval(instant), instant) };
+}
+
+async function handleSchedule(url) {
+  const options = parseOptions(url.searchParams);
+  const instant = parseInstant(url.searchParams);
+  const schedule = await calendars.current(options);
+  const periods = schedule.periodsForDate(instant);
+  return {
+    periods: periods.map((p) => ({
+      name: p.name,
+      start: p.start.toString(),
+      end: p.end.toString(),
+      tags: p.tags,
+    })),
+  };
+}
+
+async function handleStatus(url) {
+  const options = parseOptions(url.searchParams);
+  const instant = parseInstant(url.searchParams);
+  const schedule = await calendars.current(options);
+  const dayBounds = schedule.currentDayBounds(instant);
+  return {
+    interval: serializeInterval(schedule.currentInterval(instant), instant),
+    dayBounds: dayBounds
+      ? { start: dayBounds.start.toString(), end: dayBounds.end.toString() }
+      : null,
+    schoolDaysLeft: schedule.schoolDaysLeft(instant),
+    calendarDaysLeft: schedule.calendarDaysLeft(instant),
+    schoolTimeLeftSeconds: durationToSeconds(schedule.schoolTimeLeft(instant)),
+    schoolTimeDoneSeconds: durationToSeconds(schedule.schoolTimeDone(instant)),
+    totalSchoolTimeSeconds: durationToSeconds(schedule.totalSchoolTime(instant)),
+  };
+}
+
+const routes = {
+  '/api/current': handleCurrent,
+  '/api/schedule': handleSchedule,
+  '/api/status': handleStatus,
+};
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'GET') {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  const handler = routes[url.pathname];
+  if (!handler) {
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found', endpoints: Object.keys(routes) }));
+    return;
+  }
+
+  try {
+    const result = await handler(url);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(result));
+  } catch (err) {
+    console.error(`${req.method} ${req.url}:`, err.message);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Bells API server on http://localhost:${PORT}`);
+  console.log(`Calendars: ${CALENDARS_PATH}`);
+});

--- a/server/README.md
+++ b/server/README.md
@@ -26,19 +26,22 @@ All endpoints accept the following query parameters:
 |---|---|---|---|
 | `role` | `student`, `teacher` | `student` | Which schedule to use |
 | `includeTags` | `zero`, `seventh`, `ext` | _(none)_ | Optional periods to include, comma-separated |
-| `time` | ISO 8601 instant | now | Override the current time (useful for testing) |
+| `time` | ISO 8601 instant | now | Instant to query, e.g. `2026-01-15T10:30:00-08:00` |
+| `date` | YYYY-MM-DD | _(today)_ | Date to query at the current time of day; shorthand for `time=` when you only want to change the date |
+
+`time` and `date` are mutually exclusive; `time` takes precedence.
 
 ---
 
 ### `GET /api/current`
 
-Returns the current interval — the period, passing time, break, or before/after-school window that is active right now.
+Returns the interval active at the given instant — the period, passing time, break, or before/after-school window.
 
 **Response fields:**
 
 | Field | Type | Description |
 |---|---|---|
-| `interval` | object \| null | The current interval, or `null` if outside any tracked interval |
+| `interval` | object \| null | The active interval, or `null` if outside any tracked interval |
 | `interval.name` | string | e.g. `"Period 3"`, `"Lunch"`, `"Passing to Period 4"`, `"Winter Break!"` |
 | `interval.type` | string | `period`, `passing`, `before-school`, `after-school`, or `break` |
 | `interval.start` | string | ISO 8601 instant |
@@ -48,7 +51,7 @@ Returns the current interval — the period, passing time, break, or before/afte
 | `interval.duringSchool` | boolean | `true` if this interval falls within school hours |
 | `interval.tags` | string[] | Period tags, e.g. `["optional", "zero"]` |
 
-**Example:**
+**Example — current moment:**
 
 ```
 GET /api/current
@@ -69,32 +72,23 @@ GET /api/current
 }
 ```
 
-**Example (during a break):**
+**Example — specific instant:**
 
 ```
-GET /api/current
+GET /api/current?time=2026-03-17T10:30:00-07:00
 ```
 
-```json
-{
-  "interval": {
-    "name": "Long weekend!",
-    "type": "break",
-    "start": "2026-03-13T22:33:00Z",
-    "end": "2026-03-17T14:26:00Z",
-    "secondsLeft": 142608,
-    "secondsDone": 173772,
-    "duringSchool": false,
-    "tags": []
-  }
-}
+**Example — same time of day on a different date:**
+
+```
+GET /api/current?date=2026-04-01
 ```
 
 ---
 
 ### `GET /api/schedule`
 
-Returns the list of periods for the current school day (or the next school day if school is not in session today).
+Returns the list of periods for the school day containing the given instant, or the next school day if the instant falls outside school hours.
 
 **Response fields:**
 
@@ -106,7 +100,7 @@ Returns the list of periods for the current school day (or the next school day i
 | `periods[].end` | string | ISO 8601 instant |
 | `periods[].tags` | string[] | e.g. `["optional", "zero"]` |
 
-**Example:**
+**Example — today's schedule:**
 
 ```
 GET /api/schedule
@@ -126,7 +120,13 @@ GET /api/schedule
 }
 ```
 
-**Example with optional periods:**
+**Example — schedule for a specific date:**
+
+```
+GET /api/schedule?date=2026-04-06
+```
+
+**Example — schedule with optional periods:**
 
 ```
 GET /api/schedule?includeTags=zero,seventh
@@ -146,13 +146,13 @@ GET /api/schedule?includeTags=zero,seventh
 
 ### `GET /api/status`
 
-Returns a comprehensive snapshot: current interval, today's school day bounds, and year-level counters.
+Returns a comprehensive snapshot: the active interval, the school day bounds, and year-level counters.
 
 **Response fields:**
 
 | Field | Type | Description |
 |---|---|---|
-| `interval` | object \| null | Current interval (same shape as `/api/current`) |
+| `interval` | object \| null | Active interval (same shape as `/api/current`) |
 | `dayBounds` | object \| null | School day start/end, or `null` if not a school day |
 | `dayBounds.start` | string | ISO 8601 instant — first bell of the day |
 | `dayBounds.end` | string | ISO 8601 instant — last bell of the day |
@@ -192,14 +192,14 @@ GET /api/status
 }
 ```
 
----
-
-## Testing with a time override
-
-All endpoints accept a `time` query parameter to simulate a specific moment, which is useful for testing without waiting for the real clock.
+**Example — status as it would be at this time on a future date:**
 
 ```
-GET /api/current?time=2026-03-17T10:30:00-07:00
+GET /api/status?date=2026-06-01
+```
+
+**Example — teacher view at a specific instant:**
+
+```
 GET /api/status?time=2026-03-17T10:30:00-07:00&role=teacher
-GET /api/schedule?time=2026-03-17T10:30:00-07:00&includeTags=zero
 ```

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,205 @@
+# Bells API Server
+
+A REST API server wrapping the [@peterseibel/bells](https://www.npmjs.com/package/@peterseibel/bells) library to expose Berkeley High School bell schedule data over HTTP.
+
+## Running
+
+```bash
+npm install
+node index.js
+```
+
+The server listens on port 3000 by default.
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `PORT` | `3000` | Port to listen on |
+| `CALENDARS_PATH` | `./calendars/` (or `../calendars/`) | Path to directory containing per-year calendar JSON files |
+
+## Endpoints
+
+All endpoints accept the following query parameters:
+
+| Parameter | Values | Default | Description |
+|---|---|---|---|
+| `role` | `student`, `teacher` | `student` | Which schedule to use |
+| `includeTags` | `zero`, `seventh`, `ext` | _(none)_ | Optional periods to include, comma-separated |
+| `time` | ISO 8601 instant | now | Override the current time (useful for testing) |
+
+---
+
+### `GET /api/current`
+
+Returns the current interval — the period, passing time, break, or before/after-school window that is active right now.
+
+**Response fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `interval` | object \| null | The current interval, or `null` if outside any tracked interval |
+| `interval.name` | string | e.g. `"Period 3"`, `"Lunch"`, `"Passing to Period 4"`, `"Winter Break!"` |
+| `interval.type` | string | `period`, `passing`, `before-school`, `after-school`, or `break` |
+| `interval.start` | string | ISO 8601 instant |
+| `interval.end` | string | ISO 8601 instant |
+| `interval.secondsLeft` | number | Seconds until the interval ends |
+| `interval.secondsDone` | number | Seconds since the interval started |
+| `interval.duringSchool` | boolean | `true` if this interval falls within school hours |
+| `interval.tags` | string[] | Period tags, e.g. `["optional", "zero"]` |
+
+**Example:**
+
+```
+GET /api/current
+```
+
+```json
+{
+  "interval": {
+    "name": "Period 3",
+    "type": "period",
+    "start": "2026-03-17T17:43:00Z",
+    "end": "2026-03-17T18:41:00Z",
+    "secondsLeft": 1740,
+    "secondsDone": 1140,
+    "duringSchool": true,
+    "tags": []
+  }
+}
+```
+
+**Example (during a break):**
+
+```
+GET /api/current
+```
+
+```json
+{
+  "interval": {
+    "name": "Long weekend!",
+    "type": "break",
+    "start": "2026-03-13T22:33:00Z",
+    "end": "2026-03-17T14:26:00Z",
+    "secondsLeft": 142608,
+    "secondsDone": 173772,
+    "duringSchool": false,
+    "tags": []
+  }
+}
+```
+
+---
+
+### `GET /api/schedule`
+
+Returns the list of periods for the current school day (or the next school day if school is not in session today).
+
+**Response fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `periods` | object[] | Ordered list of periods for the day |
+| `periods[].name` | string | e.g. `"Period 1"`, `"Lunch"` |
+| `periods[].start` | string | ISO 8601 instant |
+| `periods[].end` | string | ISO 8601 instant |
+| `periods[].tags` | string[] | e.g. `["optional", "zero"]` |
+
+**Example:**
+
+```
+GET /api/schedule
+```
+
+```json
+{
+  "periods": [
+    { "name": "Period 1", "start": "2026-03-17T15:30:00Z", "end": "2026-03-17T16:28:00Z", "tags": [] },
+    { "name": "Period 2", "start": "2026-03-17T16:34:00Z", "end": "2026-03-17T17:37:00Z", "tags": [] },
+    { "name": "Period 3", "start": "2026-03-17T17:43:00Z", "end": "2026-03-17T18:41:00Z", "tags": [] },
+    { "name": "Lunch",    "start": "2026-03-17T18:41:00Z", "end": "2026-03-17T19:21:00Z", "tags": [] },
+    { "name": "Period 4", "start": "2026-03-17T19:27:00Z", "end": "2026-03-17T20:25:00Z", "tags": [] },
+    { "name": "Period 5", "start": "2026-03-17T20:31:00Z", "end": "2026-03-17T21:29:00Z", "tags": [] },
+    { "name": "Period 6", "start": "2026-03-17T21:35:00Z", "end": "2026-03-17T22:33:00Z", "tags": [] }
+  ]
+}
+```
+
+**Example with optional periods:**
+
+```
+GET /api/schedule?includeTags=zero,seventh
+```
+
+```json
+{
+  "periods": [
+    { "name": "Period 0", "start": "2026-03-17T14:26:00Z", "end": "2026-03-17T15:24:00Z", "tags": ["optional", "zero"] },
+    { "name": "Period 1", "start": "2026-03-17T15:30:00Z", "end": "2026-03-17T16:28:00Z", "tags": [] },
+    ...
+  ]
+}
+```
+
+---
+
+### `GET /api/status`
+
+Returns a comprehensive snapshot: current interval, today's school day bounds, and year-level counters.
+
+**Response fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `interval` | object \| null | Current interval (same shape as `/api/current`) |
+| `dayBounds` | object \| null | School day start/end, or `null` if not a school day |
+| `dayBounds.start` | string | ISO 8601 instant — first bell of the day |
+| `dayBounds.end` | string | ISO 8601 instant — last bell of the day |
+| `schoolDaysLeft` | number | School days remaining in the year (including today if in progress) |
+| `calendarDaysLeft` | number | Calendar days until the last day of school |
+| `schoolTimeLeftSeconds` | number | School instruction time remaining in the year, in seconds |
+| `schoolTimeDoneSeconds` | number | School instruction time elapsed so far, in seconds |
+| `totalSchoolTimeSeconds` | number | Total school instruction time for the year, in seconds |
+
+**Example:**
+
+```
+GET /api/status
+```
+
+```json
+{
+  "interval": {
+    "name": "Period 3",
+    "type": "period",
+    "start": "2026-03-17T17:43:00Z",
+    "end": "2026-03-17T18:41:00Z",
+    "secondsLeft": 1740,
+    "secondsDone": 1140,
+    "duringSchool": true,
+    "tags": []
+  },
+  "dayBounds": {
+    "start": "2026-03-17T15:30:00Z",
+    "end": "2026-03-17T22:33:00Z"
+  },
+  "schoolDaysLeft": 51,
+  "calendarDaysLeft": 82,
+  "schoolTimeLeftSeconds": 1407060,
+  "schoolTimeDoneSeconds": 3552480,
+  "totalSchoolTimeSeconds": 4959540
+}
+```
+
+---
+
+## Testing with a time override
+
+All endpoints accept a `time` query parameter to simulate a specific moment, which is useful for testing without waiting for the real clock.
+
+```
+GET /api/current?time=2026-03-17T10:30:00-07:00
+GET /api/status?time=2026-03-17T10:30:00-07:00&role=teacher
+GET /api/schedule?time=2026-03-17T10:30:00-07:00&includeTags=zero
+```

--- a/server/index.js
+++ b/server/index.js
@@ -17,10 +17,11 @@
  *                   (falls back to ../calendars/ relative to this file for dev)
  */
 
-import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
+import express from 'express';
+import cors from 'cors';
 import { Temporal } from '@js-temporal/polyfill';
 import { Calendars } from '@peterseibel/bells/calendars';
 
@@ -29,33 +30,30 @@ globalThis.Temporal = Temporal;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.PORT || 3000;
 
-function defaultCalendarsPath() {
+const defaultCalendarsPath = () => {
   const local = join(__dirname, 'calendars');
   if (existsSync(local)) return local + '/';
   return join(__dirname, '..', 'calendars') + '/';
-}
+};
 
 const CALENDARS_PATH = process.env.CALENDARS_PATH ?? defaultCalendarsPath();
 
 const calendars = new Calendars(CALENDARS_PATH);
 
-function parseOptions(searchParams) {
-  const role = searchParams.get('role') || 'student';
-  const raw = searchParams.get('includeTags');
+const parseOptions = (query) => {
+  const role = query.role || 'student';
+  const raw = query.includeTags;
   const includeTags = raw ? raw.split(',').map((s) => s.trim()).filter(Boolean) : [];
   return { role, includeTags };
-}
+};
 
-function parseInstant(searchParams) {
-  const raw = searchParams.get('time');
-  return raw ? Temporal.Instant.from(raw) : Temporal.Now.instant();
-}
+const parseInstant = (query) => {
+  return query.time ? Temporal.Instant.from(query.time) : Temporal.Now.instant();
+};
 
-function durationToSeconds(duration) {
-  return Math.round(duration.total({ unit: 'seconds' }));
-}
+const durationToSeconds = (duration) => Math.round(duration.total({ unit: 'seconds' }));
 
-function serializeInterval(interval, now) {
+const serializeInterval = (interval, now) => {
   if (!interval) return null;
   return {
     name: interval.name,
@@ -67,36 +65,36 @@ function serializeInterval(interval, now) {
     duringSchool: interval.duringSchool,
     tags: interval.tags,
   };
-}
+};
 
-async function handleCurrent(url) {
-  const options = parseOptions(url.searchParams);
-  const instant = parseInstant(url.searchParams);
+const handleCurrent = async (req, res) => {
+  const options = parseOptions(req.query);
+  const instant = parseInstant(req.query);
   const schedule = await calendars.current(options);
-  return { interval: serializeInterval(schedule.currentInterval(instant), instant) };
-}
+  res.json({ interval: serializeInterval(schedule.currentInterval(instant), instant) });
+};
 
-async function handleSchedule(url) {
-  const options = parseOptions(url.searchParams);
-  const instant = parseInstant(url.searchParams);
+const handleSchedule = async (req, res) => {
+  const options = parseOptions(req.query);
+  const instant = parseInstant(req.query);
   const schedule = await calendars.current(options);
   const periods = schedule.periodsForDate(instant);
-  return {
+  res.json({
     periods: periods.map((p) => ({
       name: p.name,
       start: p.start.toString(),
       end: p.end.toString(),
       tags: p.tags,
     })),
-  };
-}
+  });
+};
 
-async function handleStatus(url) {
-  const options = parseOptions(url.searchParams);
-  const instant = parseInstant(url.searchParams);
+const handleStatus = async (req, res) => {
+  const options = parseOptions(req.query);
+  const instant = parseInstant(req.query);
   const schedule = await calendars.current(options);
   const dayBounds = schedule.currentDayBounds(instant);
-  return {
+  res.json({
     interval: serializeInterval(schedule.currentInterval(instant), instant),
     dayBounds: dayBounds
       ? { start: dayBounds.start.toString(), end: dayBounds.end.toString() }
@@ -106,53 +104,17 @@ async function handleStatus(url) {
     schoolTimeLeftSeconds: durationToSeconds(schedule.schoolTimeLeft(instant)),
     schoolTimeDoneSeconds: durationToSeconds(schedule.schoolTimeDone(instant)),
     totalSchoolTimeSeconds: durationToSeconds(schedule.totalSchoolTime(instant)),
-  };
-}
-
-const routes = {
-  '/api/current': handleCurrent,
-  '/api/schedule': handleSchedule,
-  '/api/status': handleStatus,
+  });
 };
 
-const server = createServer(async (req, res) => {
-  const url = new URL(req.url, 'http://localhost');
+const app = express();
+app.use(cors());
 
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+app.get('/api/current', handleCurrent);
+app.get('/api/schedule', handleSchedule);
+app.get('/api/status', handleStatus);
 
-  if (req.method === 'OPTIONS') {
-    res.writeHead(204);
-    res.end();
-    return;
-  }
-
-  if (req.method !== 'GET') {
-    res.writeHead(405, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Method not allowed' }));
-    return;
-  }
-
-  const handler = routes[url.pathname];
-  if (!handler) {
-    res.writeHead(404, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Not found', endpoints: Object.keys(routes) }));
-    return;
-  }
-
-  try {
-    const result = await handler(url);
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(result));
-  } catch (err) {
-    console.error(`${req.method} ${req.url}:`, err.message);
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: err.message }));
-  }
-});
-
-server.listen(PORT, () => {
+app.listen(PORT, () => {
   console.log(`Bells API server on http://localhost:${PORT}`);
   console.log(`Calendars: ${CALENDARS_PATH}`);
 });

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,8 @@
  * Query parameters (all endpoints):
  *   role=student|teacher    default: student
  *   includeTags=zero,seventh,ext   optional periods to include (comma-separated)
- *   time=<ISO 8601 instant> override "now" for testing (e.g. 2026-01-15T10:30:00-08:00)
+ *   time=<ISO 8601 instant> instant to query (e.g. 2026-01-15T10:30:00-08:00); defaults to now
+ *   date=<YYYY-MM-DD>       date to query at the current time of day; shorthand for time=
  *
  * Environment:
  *   PORT            default: 3000
@@ -47,8 +48,18 @@ const parseOptions = (query) => {
   return { role, includeTags };
 };
 
+const TZ = 'America/Los_Angeles';
+
 const parseInstant = (query) => {
-  return query.time ? Temporal.Instant.from(query.time) : Temporal.Now.instant();
+  if (query.time) return Temporal.Instant.from(query.time);
+  if (query.date) {
+    const now = Temporal.Now.zonedDateTimeISO(TZ);
+    return Temporal.PlainDate.from(query.date)
+      .toPlainDateTime(now.toPlainTime())
+      .toZonedDateTime(TZ)
+      .toInstant();
+  }
+  return Temporal.Now.instant();
 };
 
 const durationToSeconds = (duration) => Math.round(duration.total({ unit: 'seconds' }));

--- a/server/index.js
+++ b/server/index.js
@@ -14,11 +14,13 @@
  * Environment:
  *   PORT            default: 3000
  *   CALENDARS_PATH  path to calendars/ directory, default: <script dir>/calendars/
+ *                   (falls back to ../calendars/ relative to this file for dev)
  */
 
 import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { Temporal } from '@js-temporal/polyfill';
 import { Calendars } from '@peterseibel/bells/calendars';
 
@@ -26,7 +28,14 @@ globalThis.Temporal = Temporal;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.PORT || 3000;
-const CALENDARS_PATH = process.env.CALENDARS_PATH ?? join(__dirname, 'calendars') + '/';
+
+function defaultCalendarsPath() {
+  const local = join(__dirname, 'calendars');
+  if (existsSync(local)) return local + '/';
+  return join(__dirname, '..', 'calendars') + '/';
+}
+
+const CALENDARS_PATH = process.env.CALENDARS_PATH ?? defaultCalendarsPath();
 
 const calendars = new Calendars(CALENDARS_PATH);
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
-        "@peterseibel/bells": "^0.1.9"
+        "@peterseibel/bells": "^0.1.9",
+        "cors": "^2.8.5",
+        "express": "^5.1.0"
       }
     },
     "node_modules/@js-temporal/polyfill": {
@@ -35,11 +37,848 @@
         "@js-temporal/polyfill": ">=0.4"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/jsbi": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
       "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
       "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
+        "@peterseibel/bells": "^0.1.9"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@peterseibel/bells": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@peterseibel/bells/-/bells-0.1.9.tgz",
+      "integrity": "sha512-PmD8jn9XkqEa1Ode6yNy3n23PYpp2CMgbb2vLsT2rUGJfrksn+nsz3nHQSYo0yHh04WmrRh7XPHMA9C0NICw9Q==",
+      "dependencies": {
+        "@peterseibel/bells": "^0.1.6"
+      },
+      "bin": {
+        "bells-validate": "src/bin/validate.js"
+      },
+      "peerDependencies": {
+        "@js-temporal/polyfill": ">=0.4"
+      }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,8 @@
   },
   "dependencies": {
     "@js-temporal/polyfill": "^0.5.1",
-    "@peterseibel/bells": "^0.1.9"
+    "@peterseibel/bells": "^0.1.9",
+    "cors": "^2.8.5",
+    "express": "^5.1.0"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,10 @@
+{
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@js-temporal/polyfill": "^0.5.1",
+    "@peterseibel/bells": "^0.1.9"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `server/` subdirectory with a Node.js REST API server wrapping `@peterseibel/bells`
- `server/package.json` lists only the server's dependencies (no web app deps)
- Adds `make serve` target to run the server during development

## Endpoints

| Endpoint | Description |
|---|---|
| `GET /api/current` | Current interval (period, passing, break, etc.) |
| `GET /api/schedule` | Periods for the current or next school day |
| `GET /api/status` | Interval + day bounds + year counters |

All endpoints accept `role=student\|teacher`, `includeTags=zero,seventh,ext`, and `time=<ISO 8601>` query params.

## Deployment

Drop `server/` alongside a `calendars/` directory. The server finds `./calendars/` by default, falling back to `../calendars/` for dev convenience. Configure with `PORT` and `CALENDARS_PATH` env vars.

## Test plan

- [ ] `cd server && npm install && node index.js`
- [ ] `curl http://localhost:3000/api/current`
- [ ] `curl http://localhost:3000/api/schedule`
- [ ] `curl http://localhost:3000/api/status`
- [ ] Test `?time=` override: `curl "http://localhost:3000/api/current?time=2026-03-17T10:00:00-07:00"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)